### PR TITLE
Handle BadStatusLine on Python 2.7.16+

### DIFF
--- a/couchdb/http.py
+++ b/couchdb/http.py
@@ -340,8 +340,11 @@ class Session(object):
                 # httplib raises a BadStatusLine when it cannot read the status
                 # line saying, "Presumably, the server closed the connection
                 # before sending a valid response."
+                # Python 2.7.16+ raises BadStatusLine('No status line received - the server has closed the connection').
+                # Python 3.5+ raises RemoteDisconnected.
                 # Raise as ECONNRESET to simplify retry logic.
-                if e.line == '' or e.line == "''":
+                if (e.line == '' or e.line == "''" or
+                    e.line == 'No status line received - the server has closed the connection'):
                     raise socket.error(errno.ECONNRESET)
                 else:
                     raise

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ else:
 
 setup(
     name = 'CouchDB',
-    version = '1.2.2-m3d',
+    version = '1.2.1.post1+m3d',
     description = 'Python library for working with CouchDB',
     long_description = \
 """This is a Python library for CouchDB. It provides a convenient high level

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ else:
 
 setup(
     name = 'CouchDB',
-    version = '1.2.1',
+    version = '1.2.2-m3d',
     description = 'Python library for working with CouchDB',
     long_description = \
 """This is a Python library for CouchDB. It provides a convenient high level


### PR DESCRIPTION
Python 2.7.16 changed how `BadStatusLine` exception is raised. Without this change the retry logic breaks when a connection is reset or closed by the remote host.

Python 3.5+ raises `RemoteDisconnected`, but it is outside the scope of this change.